### PR TITLE
Add SMBIOS OEM Strings support

### DIFF
--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -34,6 +34,10 @@ pub struct Args {
     /// GUI option for compatibility with vfkit (ignored).
     #[arg(long, default_value_t = false)]
     pub gui: bool,
+
+    /// SMBIOS OEM String
+    #[arg(long = "oem-string")]
+    pub oem_strings: Option<Vec<String>>,
 }
 
 /// Parse a string into a vector of substrings, all of which are separated by commas.


### PR DESCRIPTION
Add a new commandline option `--oem-string <STRING>` to support SMBIOS OEM strings via calling the new libkrun's API `krun_set_smbios_oem_strings()`[0].

Note: this is marked as draft until [0] is merged

[0] https://github.com/containers/libkrun/pull/187

