### PR TITLE
Fix github runner

### DIFF
--- a/.github/workflows/code_quality-aarch64-darwin.yml
+++ b/.github/workflows/code_quality-aarch64-darwin.yml
@@ -5,7 +5,7 @@ jobs:
   build:
     if: github.event_name == 'pull_request'
     name: Code Quality (clippy, rustfmt)
-    runs-on: fedora-latest
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         rust:


### PR DESCRIPTION
github only provides ubuntu as linux hosted runner[0]

[0] https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners