### PR TITLE
Support additional image types

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -46,6 +46,7 @@ as a virtual machine's data disk (`/dev/vdb`).
 #### Arguments
 
 - `path`: Path to the disk image file.
+- `format`: Format of the disk image. Supported formats: raw, qcow2.
 
 #### Example
 
@@ -53,7 +54,7 @@ This adds a virtio-blk device to a virtual machine which will be backed by a raw
 `/Users/user/disk-image.raw`:
 
 ```
---device virtio-blk,path=/Users/user/disk-image.raw
+--device virtio-blk,path=/Users/user/disk-image.raw,format=raw
 ```
 
 ### Networking

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -191,13 +191,13 @@ mod tests {
             "--bootloader",
             "efi,variable-store=/Users/user/bootloader,create",
             "--device",
-            "virtio-blk,path=/Users/user/root.raw",
+            "virtio-blk,path=/Users/user/root.qcow2,format=qcow2",
             "--device",
             "virtio-rng",
             "--device",
             "virtio-serial,logFilePath=/Users/user/serial.log",
             "--device",
-            "virtio-blk,path=/Users/user/data.raw",
+            "virtio-blk,path=/Users/user/data.raw,format=raw",
             "--device",
             "virtio-vsock,port=1024,socketURL=/Users/user/vsock1.sock,listen",
             "--device",
@@ -299,6 +299,7 @@ mod tests {
             .expect("expected 4th virtio device config");
         if let VirtioDeviceConfig::Blk(blk) = blk {
             assert_eq!(blk.path, PathBuf::from_str("/Users/user/data.raw").unwrap());
+            assert_eq!(blk.format, DiskImageFormat::Raw);
         } else {
             panic!("expected virtio-blk device as 4th device config argument");
         }
@@ -330,7 +331,11 @@ mod tests {
             .pop()
             .expect("expected 1st virtio device config");
         if let VirtioDeviceConfig::Blk(blk) = blk {
-            assert_eq!(blk.path, PathBuf::from_str("/Users/user/root.raw").unwrap());
+            assert_eq!(
+                blk.path,
+                PathBuf::from_str("/Users/user/root.qcow2").unwrap()
+            );
+            assert_eq!(blk.format, DiskImageFormat::Qcow2);
         } else {
             panic!("expected virtio-blk device as 1st device config argument");
         }


### PR DESCRIPTION
Extend the command line to support the new `krun_add_disk2` API in libkrun. This will allow the user to specify non-Raw disk image formats. The list of supported disk image formats is now: Raw, Qcow2.