### PR TITLE
Prepend /usr/local/lib to rustc link search path

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -2,5 +2,5 @@
 
 fn main() {
     #[cfg(target_os = "macos")]
-    println!("cargo:rustc-link-search=/opt/homebrew/lib");
+    println!("cargo:rustc-link-search=/usr/local/lib:/opt/homebrew/lib");
 }


### PR DESCRIPTION
This allows building and installing libkrun from git.

In libkrun:

    make EFI=1
    sudo make EFI=1 install

In krunkit:

    make
    install_name_tool -change libkrun-efi.dylib /usr/local/lib/libkrun-efi.dylib target/release/krunkit
    codesign --remove-signature target/release/krunkit
    codesign --entitlements krunkit.entitlements --force -s - target/release/krunkit

We probably should integrate this in the Makefile so it works out of the box.

I did not test building with older libkrun-efi.dylib from brew. Currently we fail to compile with the older version since we use new symbol available only in latest libkrun.