### PR TITLE
Set default log level to INFO

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -8,6 +8,10 @@ will require a root disk to be useful.
 
 ## Generic Options
 
+- `--krun-log-level`
+
+Set the log level for libkrun. Supported values: 0=off, 1=error, 2=warn, 3=info (default), 4=debug, 5=trace.
+
 - `--restful-uri`
 
 The URI (address) of the RESTful service. If not specified, defaults to `tcp://localhost:8081`. `tcp` is the only

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -40,7 +40,7 @@ pub struct Args {
     pub oem_strings: Option<Vec<String>>,
 
     /// Log level for libkrun (0=off, 1=error, 2=warn, 3=info, 4=debug, 5 or higher=trace)
-    #[arg(long = "krun-log-level", default_value_t = 0)]
+    #[arg(long = "krun-log-level", default_value_t = 3)]
     pub krun_log_level: u32,
 }
 
@@ -213,6 +213,8 @@ mod tests {
             "--restful-uri",
             "tcp://localhost:49573",
             "--gui",
+            "--krun-log-level",
+            "5",
         ];
 
         let mut args = Args::try_parse_from(cmdline).unwrap();
@@ -346,5 +348,6 @@ mod tests {
         assert_eq!(restful_uri.port, 49573);
 
         assert_eq!(args.gui, true);
+        assert_eq!(args.krun_log_level, 5);
     }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -36,6 +36,13 @@ impl TryFrom<Args> for KrunContext {
     type Error = anyhow::Error;
 
     fn try_from(args: Args) -> Result<Self, Self::Error> {
+        if args.krun_log_level > 5 {
+            return Err(anyhow!(format!(
+                "invalid log level value: {}",
+                args.krun_log_level
+            )));
+        }
+
         // Start by setting up the desired log level for libkrun.
         unsafe { krun_set_log_level(args.krun_log_level) };
 


### PR DESCRIPTION
Changes the default krun_log_level to INFO instead of off. This is in line with vfkit's behavior.

Adds `--krun-log-level` to `docs/usage.md`.

Fixes: #31