### PR TITLE
Re-write argument parsing

### DIFF
--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -264,6 +264,29 @@ mod tests {
     }
 
     #[test]
+    fn virtio_vsock_argument_ordering() {
+        let in_order = super::parse_args(String::from(
+            "port=1025,socketURL=/Users/user/vsock2.sock,listen",
+        ))
+        .unwrap();
+        let out_of_order = super::parse_args(String::from(
+            "port=1025,listen,socketURL=/Users/user/vsock2.sock",
+        ))
+        .unwrap();
+
+        let mut expected = std::collections::HashMap::new();
+        expected.insert("port".to_string(), "1025".to_string());
+        expected.insert(
+            "socketURL".to_string(),
+            "/Users/user/vsock2.sock".to_string(),
+        );
+        expected.insert("listen".to_string(), String::new());
+
+        assert_eq!(in_order, out_of_order);
+        assert_eq!(in_order, expected);
+    }
+
+    #[test]
     fn argument_parsing() {
         let s = String::from("port=1025,socketURL=/Users/user/vsock2.sock,listen");
         let args = super::parse_args(s).unwrap();

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -309,6 +309,19 @@ mod tests {
     }
 
     #[test]
+    fn virtio_gpu_argument_ordering() {
+        let in_order = super::parse_args(String::from("height=50,width=25")).unwrap();
+        let out_of_order = super::parse_args(String::from("width=25,height=50")).unwrap();
+
+        let mut expected = std::collections::HashMap::new();
+        expected.insert("height".to_string(), "50".to_string());
+        expected.insert("width".to_string(), "25".to_string());
+
+        assert_eq!(in_order, out_of_order);
+        assert_eq!(in_order, expected);
+    }
+
+    #[test]
     fn argument_parsing() {
         let s = String::from("port=1025,socketURL=/Users/user/vsock2.sock,listen");
         let args = super::parse_args(s).unwrap();

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -242,6 +242,28 @@ mod tests {
     }
 
     #[test]
+    fn virtio_net_argument_ordering() {
+        let in_order = super::parse_args(String::from(
+            "unixSocketPath=/Users/user/vm-network.sock,mac=ff:ff:ff:ff:ff:ff",
+        ))
+        .unwrap();
+        let out_of_order = super::parse_args(String::from(
+            "mac=ff:ff:ff:ff:ff:ff,unixSocketPath=/Users/user/vm-network.sock",
+        ))
+        .unwrap();
+
+        let mut expected = std::collections::HashMap::new();
+        expected.insert(
+            "unixSocketPath".to_string(),
+            "/Users/user/vm-network.sock".to_string(),
+        );
+        expected.insert("mac".to_string(), "ff:ff:ff:ff:ff:ff".to_string());
+
+        assert_eq!(in_order, out_of_order);
+        assert_eq!(in_order, expected);
+    }
+
+    #[test]
     fn argument_parsing() {
         let s = String::from("port=1025,socketURL=/Users/user/vsock2.sock,listen");
         let args = super::parse_args(s).unwrap();

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -287,6 +287,28 @@ mod tests {
     }
 
     #[test]
+    fn virtio_fs_argument_ordering() {
+        let in_order = super::parse_args(String::from(
+            "sharedDir=/Users/user/shared-dir,mountTag=MOUNT_TAG",
+        ))
+        .unwrap();
+        let out_of_order = super::parse_args(String::from(
+            "mountTag=MOUNT_TAG,sharedDir=/Users/user/shared-dir",
+        ))
+        .unwrap();
+
+        let mut expected = std::collections::HashMap::new();
+        expected.insert(
+            "sharedDir".to_string(),
+            "/Users/user/shared-dir".to_string(),
+        );
+        expected.insert("mountTag".to_string(), "MOUNT_TAG".to_string());
+
+        assert_eq!(in_order, out_of_order);
+        assert_eq!(in_order, expected);
+    }
+
+    #[test]
     fn argument_parsing() {
         let s = String::from("port=1025,socketURL=/Users/user/vsock2.sock,listen");
         let args = super::parse_args(s).unwrap();

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -227,6 +227,21 @@ mod bootloader {
 
 mod tests {
     #[test]
+    fn virtio_blk_argument_ordering() {
+        let in_order =
+            super::parse_args(String::from("path=/Users/user/disk-image.raw,format=raw")).unwrap();
+        let out_of_order =
+            super::parse_args(String::from("format=raw,path=/Users/user/disk-image.raw")).unwrap();
+
+        let mut expected = std::collections::HashMap::new();
+        expected.insert("path".to_string(), "/Users/user/disk-image.raw".to_string());
+        expected.insert("format".to_string(), "raw".to_string());
+
+        assert_eq!(in_order, out_of_order);
+        assert_eq!(in_order, expected);
+    }
+
+    #[test]
     fn argument_parsing() {
         let s = String::from("port=1025,socketURL=/Users/user/vsock2.sock,listen");
         let args = super::parse_args(s).unwrap();

--- a/src/virtio.rs
+++ b/src/virtio.rs
@@ -187,10 +187,14 @@ impl FromStr for SerialConfig {
     type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let args = args_parse(s.to_string(), "virtio-serial", Some(1))?;
+        let mut args = parse_args(s.to_string())?;
+        check_required_args(&args, "virtio-serial", &["logFilePath"])?;
+
+        let log_file_path = args.remove("logFilePath").unwrap();
+        check_unknown_args(args, "virtio-serial")?;
 
         Ok(Self {
-            log_file_path: PathBuf::from_str(&val_parse(&args[0], "logFilePath")?)
+            log_file_path: PathBuf::from_str(log_file_path.as_str())
                 .context("logFilePath argument not a valid path")?,
         })
     }

--- a/src/virtio.rs
+++ b/src/virtio.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::cmdline::{args_parse, check_required_args, check_unknown_args, parse_args};
+use crate::cmdline::{check_required_args, check_unknown_args, parse_args};
 
 use std::{
     ffi::{c_char, CString},
@@ -72,7 +72,7 @@ impl FromStr for VirtioDeviceConfig {
     type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let args = args_parse(s.to_string(), "virtio", None)?;
+        let args: Vec<String> = s.split(',').map(|s| s.to_string()).collect();
 
         if args.is_empty() {
             return Err(anyhow!("no virtio device config found"));

--- a/src/virtio.rs
+++ b/src/virtio.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::cmdline::{args_parse, val_parse};
+use crate::cmdline::{args_parse, check_required_args, check_unknown_args, parse_args, val_parse};
 
 use std::{
     ffi::{c_char, CString},

--- a/src/virtio.rs
+++ b/src/virtio.rs
@@ -439,12 +439,22 @@ impl FromStr for InputConfig {
     type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let args = args_parse(s.to_string(), "virtio-input", Some(1))?;
+        let args = parse_args(s.to_string())?;
 
-        match &args[0].to_lowercase()[..] {
+        if args.len() != 1 {
+            return Err(anyhow!("invalid virtio-input config: {s}"));
+        }
+
+        let (key, value) = args.into_iter().next().unwrap();
+        if !value.is_empty() {
+            return Err(anyhow!(format!(
+                "unexpected value for virtio-input argument: {key}={value}"
+            )));
+        }
+        match key.as_str() {
             "keyboard" => Ok(Self::Keyboard),
             "pointing" => Ok(Self::Pointing),
-            _ => Err(anyhow!("invalid virtio-input config")),
+            _ => Err(anyhow!("unknown virtio-input argument: {key}")),
         }
     }
 }


### PR DESCRIPTION
The previous method for parsing the command-line arguments required the device arguments, for example, to be in a hard-coded order, and they were all considered required. Additionally, if a specific argument was missing, or there were extra arguments, the error messages could be somewhat vague.

These changes allow for more granular error message, optional arguments that have a default value, and for the user to put the arguments in any particular order.

Fixes: https://github.com/containers/krunkit/issues/30 