### PR TITLE
Add LIBKRUN_EFI to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 OS = $(shell uname -s)
 KRUNKIT_RELEASE = target/release/krunkit
 KRUNKIT_DEBUG = target/debug/krunkit
+KRUNKIT_HOMEBREW = /opt/homebrew/opt/libkrun-efi/lib/libkrun-efi.dylib
 
 ifeq ($(PREFIX),)
     PREFIX := /usr/local
@@ -15,6 +16,9 @@ debug: $(KRUNKIT_DEBUG)
 $(KRUNKIT_RELEASE):
 	cargo build --release
 ifeq ($(OS),Darwin)
+ifneq ($(LIBKRUN_EFI),)
+	install_name_tool -change $(KRUNKIT_HOMEBREW) $(LIBKRUN_EFI) $@
+endif
 	codesign --entitlements krunkit.entitlements --force -s - $@
 endif
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,19 @@ $ brew tap slp/krunkit
 $ brew install krunkit
 ```
 
+## Building from source
+
+As noted above, `krunkit` relies on the `efi` flavor of `libkrun`. Ensure that is installed on your system.
+
+```
+# If libkrun-efi.dylib is not located at /opt/homebrew/opt/libkrun-efi/lib/
+# provide the path at which it's located using the LIBKRUN_EFI variable. Otherwise,
+# the Makefile will default to using the /opt/homebrew/... path.
+$ make LIBKRUN_EFI=<path to libkrun-efi.dylib>
+
+$ sudo make install
+```
+
 ## Usage
 
 See [`docs/usage.md`](./docs/usage.md).


### PR DESCRIPTION
Cargo on macOS doesn't seem to respect the /usr/local/lib path in the build script (https://github.com/rust-lang/cargo/issues/4421#issuecomment-325018484). Therefore, if the user builds libkrun-efi from source or if libkrun-efi.dylib is not in /opt/homebrew/lib, then they won't be able to run the binary.

This adds an `LIBKRUN_EFI` variable that will link the specified library with the krunkit binary 
