### PR TITLE
Add a cmdline flag to request nested virt

### DIFF
--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -42,6 +42,10 @@ pub struct Args {
     /// Log level for libkrun (0=off, 1=error, 2=warn, 3=info, 4=debug, 5 or higher=trace)
     #[arg(long = "krun-log-level", default_value_t = 3)]
     pub krun_log_level: u32,
+
+    /// Enable Nested Virtualization.
+    #[arg(long, short)]
+    pub nested: bool,
 }
 
 /// Parse the input string into a hash map of key value pairs, associating the argument with its

--- a/src/context.rs
+++ b/src/context.rs
@@ -19,6 +19,7 @@ extern "C" {
     fn krun_set_gpu_options2(ctx_id: u32, virgl_flags: u32, shm_size: u64) -> i32;
     fn krun_set_vm_config(ctx_id: u32, num_vcpus: u8, ram_mib: u32) -> i32;
     fn krun_set_smbios_oem_strings(ctx_id: u32, oem_strings: *const *const c_char) -> i32;
+    fn krun_set_nested_virt(ctx_id: u32, enabled: bool) -> i32;
     fn krun_start_enter(ctx_id: u32) -> i32;
 }
 
@@ -87,6 +88,10 @@ impl TryFrom<Args> for KrunContext {
         }
 
         set_smbios_oem_strings(id, &args.oem_strings)?;
+
+        if args.nested && unsafe { krun_set_nested_virt(id, args.nested) } < 0 {
+            return Err(anyhow!("unable to set krun nested virtualization"));
+        }
 
         Ok(Self { id, args })
     }


### PR DESCRIPTION
Version 1.11 of libkrun introduces support for Nested Virtualization on macOS hosts. Let's add a flag to allow users to request its enablement.