### PR TITLE
docs: add `--nested`

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -26,6 +26,12 @@ Number of vCPUs available to a virtual machine.
 
 Amount of RAM available to a virtual machine. Value is in MiB (mebibytes, 1024^2 bytes).
 
+- `--nested`
+
+Enable Nested Virtualization.
+
+Note: this requires an M3 or newer CPU and macOS 15+.
+
 #### Example
 
 This configures a virtual machine to use two vCPUs and 2048 MiB of RAM:

--- a/src/status.rs
+++ b/src/status.rs
@@ -133,7 +133,7 @@ fn handle_incoming_stream<T: Read + Write>(stream: &mut T, shutdown_fd: &mut Fil
                 println!("Error writing GET response: {e}");
             }
         }
-        Err(e) => println!("Error reading stream: {}", e),
+        Err(e) => println!("Error reading stream: {e}"),
     }
 }
 


### PR DESCRIPTION
Document the `--nested` option in the usage page.