### PR TITLE
Add --device virtio-net,type=unix{gram,stream}

### DIFF
--- a/src/virtio.rs
+++ b/src/virtio.rs
@@ -52,7 +52,6 @@ extern "C" {
     ) -> i32;
     fn krun_add_vsock_port(ctx_id: u32, port: u32, c_filepath: *const c_char) -> i32;
     fn krun_add_virtiofs(ctx_id: u32, c_tag: *const c_char, c_path: *const c_char) -> i32;
-    fn krun_set_net_mac(ctx_id: u32, c_mac: *const u8) -> i32;
     fn krun_set_console_output(ctx_id: u32, c_filepath: *const c_char) -> i32;
     fn krun_add_net_unixgram(
         ctx_id: u32,
@@ -546,14 +545,6 @@ impl KrunContextSet for NetConfig {
                     )));
                 }
             }
-        }
-        let mac = self.mac_address.bytes();
-
-        if krun_set_net_mac(id, mac.as_ptr()) < 0 {
-            return Err(anyhow!(format!(
-                "unable to set net MAC address {}",
-                self.mac_address
-            )));
         }
 
         Ok(())


### PR DESCRIPTION
Add a new `type=unix{gram,stream}` argument option to the virtio-net device cmdline. This will allow the user to take advantage of the new `krun_add_net_unix{gram,stream}` APIs to create an independent unix datagram or stream socket-based virtio-net device.

Additionally, this PR changes the underlying implementation of the `unixSocketPath` argument to now use the `krun_add_net_unixgram` instead of the deprecated `krun_set_gvproxy_path`.

This will also allow the user to enable or disable offloading, proving them possible improvements outlined in the associated issue below.

Resolves: #58
Resolves: #56 
Resolves: #24