### PR TITLE
makefile: fix incremental builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ ifeq ($(PREFIX),)
     PREFIX := /usr/local
 endif
 
-.PHONY: install clean
+.PHONY: install clean $(KRUNKIT_RELEASE) $(KRUNKIT_DEBUG)
 
 all: $(KRUNKIT_RELEASE)
 


### PR DESCRIPTION
Allow incremental builds when doing make targets other than `install` or `clean`.