### PR TITLE
WIP: src: docs: Change --restful-uri default

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -14,7 +14,7 @@ Set the log level for libkrun. Supported values: 0=off, 1=error, 2=warn, 3=info 
 
 - `--restful-uri`
 
-The URI (address) of the RESTful service. If not specified, defaults to `tcp://localhost:8081`. Valid schemes are
+The URI (address) of the RESTful service. If not specified, defaults to `none://`. Valid schemes are
 `tcp`, `none`, or `unix`. A scheme of `none` disables the RESTful service.
 ### Virtual Machine Resources
 

--- a/src/status.rs
+++ b/src/status.rs
@@ -26,9 +26,9 @@ const HTTP_STOPPING: &str =
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum UriScheme {
-    #[default]
     Tcp,
     Unix,
+    #[default]
     None,
 }
 
@@ -101,7 +101,7 @@ fn parse_tcp_input(input: &str) -> Result<(Ipv4Addr, u16), anyhow::Error> {
 
 impl Default for RestfulUri {
     fn default() -> Self {
-        Self::Tcp(Ipv4Addr::new(127, 0, 0, 1), 8081)
+        Self::None
     }
 }
 


### PR DESCRIPTION
Due to a docs bug in vfkit, we have incidentally diverged from vfkit default behavior by using tcp as the default. Now that the argument supports none://, that should be the default instead.

Fixes: https://github.com/containers/krunkit/issues/53