### PR TITLE
context: check if restful URI scheme is None

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -172,7 +172,8 @@ impl KrunContext {
         let shutdown_eventfd = unsafe { get_shutdown_eventfd(self.id) };
         let uri = self.args.restful_uri.clone();
 
-        if uri != Some(RestfulUri::None) {
+        // Only spawn a listener thread if the user specified unix:// or tcp://
+        if uri.as_ref().is_some_and(|u| *u != RestfulUri::None) {
             thread::spawn(move || status_listener(shutdown_eventfd, uri).unwrap());
         }
 


### PR DESCRIPTION
Before starting the status listener thread, we not only need to check if the RestfulUri variant != None, but we also need to verify the user specified a restful URI scheme at all.

This prevents a panic when we call `status_listener()` due to hitting an `unreachable!()` code path. Functionally, the panic didn't affect users; it's difficult to catch since the VM starts immediately after the message is printed to stdout.